### PR TITLE
1.0.3

### DIFF
--- a/regipy/plugins/system/computer_name.py
+++ b/regipy/plugins/system/computer_name.py
@@ -23,9 +23,8 @@ class ComputerNamePlugin(Plugin):
             subkey = self.registry_hive.get_key(subkey_path)
 
             try:
-                computer_name = subkey.get_value('ComputerName', as_json=self.as_json)
                 computer_names.append({
-                    'name': computer_name.value,
+                    'name': subkey.get_value('ComputerName', as_json=self.as_json),
                     'timestamp': convert_wintime(subkey.header.last_modified, as_json=self.as_json)
                 })
             except RegistryValueNotFoundException as ex:

--- a/regipy/plugins/system/shimcache.py
+++ b/regipy/plugins/system/shimcache.py
@@ -20,7 +20,8 @@ class ShimCachePlugin(Plugin):
         shimcaches = []
         for subkey_path in self.registry_hive.get_control_sets(COMPUTER_NAME_PATH):
             appcompat_cache = self.registry_hive.get_key(subkey_path).get_key('AppCompatCache')
-            shimcache = appcompat_cache.get_value('AppCompatCache').value
-            for entry in get_shimcache_entries(shimcache, as_json=self.as_json):
-                shimcaches.append(entry)
+            shimcache = appcompat_cache.get_value('AppCompatCache')
+            if shimcache:
+                for entry in get_shimcache_entries(shimcache, as_json=self.as_json):
+                    shimcaches.append(entry)
         return shimcaches

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('docs/README.rst', 'r') as readme_file:
 def main():
     setup(name='regipy',
           packages=find_packages(),
-          version='1.0.2',
+          version='1.0.3',
           description='Python Registry Parser',
           long_description=readme,
           author='Martin G. Korman',


### PR DESCRIPTION
* changed the behavior of get_value: now it will return the value itself or `None` if not found unless `raise_on_missing=True` is specified 
* Regipy now will not raise an exception when parsing an unidentified hive type.