### PR TITLE
Fixed a bug when parsing Leaf Index objects

### DIFF
--- a/regipy/exceptions.py
+++ b/regipy/exceptions.py
@@ -34,3 +34,10 @@ class UnidentifiedHiveException(RegipyException):
 
 class RegistryRecoveryException(RegipyException):
     pass
+
+
+class RegistryParsingException(RegipyException):
+    """
+    Raised when there is a parsing error, most probably a corrupted hive
+    """
+    pass

--- a/regipy/plugins/amcache/amcache.py
+++ b/regipy/plugins/amcache/amcache.py
@@ -85,7 +85,11 @@ class AmCachePlugin(Plugin):
                             entry[v] = content
 
                     entry['sha1'] = entry['sha1'][4:]
-                    entry['program_id'] = entry['program_id'][4:]
+
+                    program_id = entry.get('program_id')
+                    if program_id:
+                        entry['program_id'] = entry['program_id'][4:]
+
                     entry['type'] = 'win_8+_amcache'
 
                     for ts_field_name in WIN8_TS_FIELDS:

--- a/regipy/structs.py
+++ b/regipy/structs.py
@@ -153,7 +153,7 @@ LF_LH_SK_ELEMENT = Struct(
     'elements' / Array(
         this.element_count,
         Struct(
-            'named_key_offset' / Int32ul,
+            'key_node_offset' / Int32ul,
             'hash_value' / Int32ul
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('docs/README.rst', 'r') as readme_file:
 def main():
     setup(name='regipy',
           packages=find_packages(),
-          version='1.2.0',
+          version='1.2.1',
           description='Python Registry Parser',
           long_description=readme,
           author='Martin G. Korman',


### PR DESCRIPTION
* Leaf Index objects `LI` inside Root Index `RI` objects were not parsed correctly. 
* Fixed a small case where `program_id` was missing in some amcache entries