### PR TITLE
Add case insensitive keyname comparison and fix ShimCacheParser condition

### DIFF
--- a/regipy/plugins/system/external/ShimCacheParser.py
+++ b/regipy/plugins/system/external/ShimCacheParser.py
@@ -326,11 +326,11 @@ def read_win10_entries(bin_data, ver_magic, creators_update=False, as_json=False
         # Read the remaining entry data
         low_datetime, high_datetime = struct.unpack('<LL', entry_data.read(8))
 
-        last_mod_date = convert_filetime(low_datetime, high_datetime)
-
         # Skip the unrecognized Microsoft App entry format for now
-        if last_mod_date == BAD_ENTRY_DATA:
-            continue
+        if not (low_datetime+high_datetime):
+        	continue
+        else:
+        	last_mod_date = convert_filetime(low_datetime, high_datetime)
 
         yield {
             'last_mod_date': last_mod_date.isoformat() if as_json else last_mod_date,

--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -299,7 +299,7 @@ class NKRecord:
             if not isinstance(subkey, NKRecord):
                 raise RegipyGeneralException(f'Unknown record type: {subkey}')
 
-            if subkey.name == key_name:
+            if subkey.name.upper() == key_name.upper():
                 return subkey
 
     def iter_subkeys(self):


### PR DESCRIPTION
Registry keys are not case sensitive ([docs.microsoft](https://docs.microsoft.com/en-us/windows/win32/sysinfo/structure-of-the-registry)) neither should be the comparison to find one.

This is relevant for key names that differ in case such as "WOW6432Node"/"Wow6432Node" and "Explorer"/"explorer".

Related git issue: #69 

---

Commit f4504a4 additionally fixes a condition in the ShimCacheParser. The check for BAD_ENTRY_DATA always returns false due to the return value of convert_wintime(). This fix checks if the actual time values are 0 instead.
