### PR TITLE
Amcache: handle extreme case for entries without SHA1

### DIFF
--- a/regipy/__init__.py
+++ b/regipy/__init__.py
@@ -1,4 +1,4 @@
 from .registry import *
 
 name = 'regipy'
-__version__ = '1.5.0'
+__version__ = '1.5.1'

--- a/regipy/plugins/amcache/amcache.py
+++ b/regipy/plugins/amcache/amcache.py
@@ -84,7 +84,11 @@ class AmCachePlugin(Plugin):
                         if content:
                             entry[v] = content
 
-                    entry['sha1'] = entry['sha1'][4:]
+                    entry_sha1 = entry.get('sha1')
+                    if entry_sha1:
+                        entry['sha1'] = entry_sha1[4:]
+                    else:
+                        logger.info(f'entry {entry} has no SHA1')
 
                     program_id = entry.get('program_id')
                     if program_id:


### PR DESCRIPTION
These subkeys do not contain the `file_id` value. 