### PR TITLE
Fix indention and convert WinXP run counter

### DIFF
--- a/regipy/plugins/ntuser/user_assist.py
+++ b/regipy/plugins/ntuser/user_assist.py
@@ -102,7 +102,7 @@ class UserAssistPlugin(Plugin):
                         }
 
                     elif len(data) == 16:
-                        parsed_entry = WIN_XP_USER_ASSIST.parse(data) 
+                        parsed_entry = WIN_XP_USER_ASSIST.parse(data)
                         entry = {
                             'name': name,
                             'timestamp': convert_wintime(parsed_entry.last_execution_timestamp, as_json=self.as_json),

--- a/regipy/plugins/ntuser/user_assist.py
+++ b/regipy/plugins/ntuser/user_assist.py
@@ -102,12 +102,12 @@ class UserAssistPlugin(Plugin):
                         }
 
                     elif len(data) == 16:
-                        parsed_entry = WIN_XP_USER_ASSIST.parse(data)
+                        parsed_entry = WIN_XP_USER_ASSIST.parse(data) 
                         entry = {
                             'name': name,
                             'timestamp': convert_wintime(parsed_entry.last_execution_timestamp, as_json=self.as_json),
                             'session_id': parsed_entry.session_id,
-                            'run_counter': parsed_entry.run_counter
+                            'run_counter': parsed_entry.run_counter - 5
                         }
 
                     if entry:

--- a/regipy/plugins/system/external/ShimCacheParser.py
+++ b/regipy/plugins/system/external/ShimCacheParser.py
@@ -328,9 +328,9 @@ def read_win10_entries(bin_data, ver_magic, creators_update=False, as_json=False
 
         # Skip the unrecognized Microsoft App entry format for now
         if not (low_datetime+high_datetime):
-        	continue
+            continue
         else:
-        	last_mod_date = convert_filetime(low_datetime, high_datetime)
+            last_mod_date = convert_filetime(low_datetime, high_datetime)
 
         yield {
             'last_mod_date': last_mod_date.isoformat() if as_json else last_mod_date,


### PR DESCRIPTION
The WinXP run counter starts at 5 by default ([scitepress.org](https://www.scitepress.org/Papers/2017/64167/pdf/index.html)). 