### PR TITLE
Ease using regipy as a library 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -36,6 +36,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python setup.py develop
-        pytest regipy_tests/tests.py -vvv
-        pytest regipy_tests/plugin_tests.py -vvv
+        pip install -e .[cli]
+        pytest regipy_tests/tests.py regipy_tests/plugin_tests.py -vvvs

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Regipy is a python library for parsing offline registry hives. regipy has a lot 
 Only python 3.6 and up is supported:
 
 ```bash
-pip install regipy
+pip install regipy[cli]
 ```
 
 also, it is possible to install from source by cloning the repository and executing:
 ```bash
-python setup.py install
+pip install --editable .[cli]
 ```
 
 ## CLI

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Regipy is a python library for parsing offline registry hives. regipy has a lot 
     * Execute plugins from a robust plugin system (i.e: amcache, shimcache, extract computer name...)
 
 ## Installation
-Only python 3.7 is supported:
+Only python 3.6 and up is supported:
+
 ```bash
 pip install regipy
 ```

--- a/README.md
+++ b/README.md
@@ -20,10 +20,21 @@ Only python 3.6 and up is supported:
 pip install regipy[cli]
 ```
 
-also, it is possible to install from source by cloning the repository and executing:
+NOTE: using pip with ``regipy[cli]`` instead of the plain ``regipy`` is a
+significant change from version 1.9.x
+
+For using regipat as a library, install only ``regipy`` which comes with fewer
+dependencies:
+```bash
+pip install regipy
+```
+
+
+Also, it is possible to install from source by cloning the repository and executing:
 ```bash
 pip install --editable .[cli]
 ```
+
 
 ## CLI
 

--- a/regipy/__init__.py
+++ b/regipy/__init__.py
@@ -1,4 +1,4 @@
 from .registry import *
 
 __title__ = 'regipy'
-__version__ = '1.9.4'
+__version__ = '2.0.0'

--- a/regipy/plugins/amcache/amcache.py
+++ b/regipy/plugins/amcache/amcache.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 
 from inflection import underscore
 
@@ -7,7 +7,7 @@ from regipy.hive_types import AMCACHE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 AMCACHE_FIELD_NUMERIC_MAPPINGS = {
     '0': 'product_name',

--- a/regipy/plugins/ntuser/classes_installer.py
+++ b/regipy/plugins/ntuser/classes_installer.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 CLASSES_INSTALLER_PATH = r'\Software\Classes\Installer\Product'
 

--- a/regipy/plugins/ntuser/installed_programs_ntuser.py
+++ b/regipy/plugins/ntuser/installed_programs_ntuser.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 
 from inflection import underscore
 
@@ -7,7 +7,7 @@ from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 INSTALLED_SOFTWARE_PATH = r'\Software\Microsoft\Windows\CurrentVersion\Uninstall'
 

--- a/regipy/plugins/ntuser/persistence.py
+++ b/regipy/plugins/ntuser/persistence.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import get_subkey_values_from_list
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 PERSISTENCE_ENTRIES = [
     r'\Software\Microsoft\Windows NT\CurrentVersion\Run',

--- a/regipy/plugins/ntuser/tsclient.py
+++ b/regipy/plugins/ntuser/tsclient.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime, NoRegistrySubkeysException
 from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 TSCLIENT_HISTORY_PATH = r'\Software\Microsoft\Terminal Server Client\Servers'
 

--- a/regipy/plugins/ntuser/typed_urls.py
+++ b/regipy/plugins/ntuser/typed_urls.py
@@ -1,11 +1,11 @@
-import logbook
+import logging
 from inflection import underscore
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 TYPED_URLS_KEY_PATH = r'\Software\Microsoft\Internet Explorer\TypedURLs'

--- a/regipy/plugins/ntuser/user_assist.py
+++ b/regipy/plugins/ntuser/user_assist.py
@@ -1,7 +1,7 @@
 import binascii
 import codecs
 
-import logbook
+import logging
 
 from construct import *
 
@@ -10,7 +10,7 @@ from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 USER_ASSIST_KEY_PATH = r'\Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist'
 

--- a/regipy/plugins/ntuser/word_wheel_query.py
+++ b/regipy/plugins/ntuser/word_wheel_query.py
@@ -1,7 +1,7 @@
 import binascii
 import codecs
 
-import logbook
+import logging
 
 from construct import *
 
@@ -10,7 +10,7 @@ from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 WORD_WHEEL_QUERY_KEY_PATH = r'\Software\Microsoft\Windows\CurrentVersion\Explorer\WordWheelQuery'
 

--- a/regipy/plugins/plugin.py
+++ b/regipy/plugins/plugin.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.registry import RegistryHive
 
 PLUGINS = set()
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Plugin(object):

--- a/regipy/plugins/plugin_template.py
+++ b/regipy/plugins/plugin_template.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import NTUSER_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import get_subkey_values_from_list
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class TemplatePlugin(Plugin):

--- a/regipy/plugins/software/classes_installer.py
+++ b/regipy/plugins/software/classes_installer.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 CLASSES_INSTALLER_PATH = r'\Classes\Installer\Products'
 

--- a/regipy/plugins/software/image_file_execution_options.py
+++ b/regipy/plugins/software/image_file_execution_options.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import get_subkey_values_from_list, convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 IMAGE_FILE_EXECUTION_OPTIONS = r'\Microsoft\Windows NT\CurrentVersion\Image File Execution Options'
 

--- a/regipy/plugins/software/installed_programs.py
+++ b/regipy/plugins/software/installed_programs.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 from inflection import underscore
 
 from regipy import RegistryKeyNotFoundException
@@ -6,7 +6,7 @@ from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 X64_INSTALLED_SOFTWARE_PATH = r'\Microsoft\Windows\CurrentVersion\Uninstall'
 X86_INSTALLED_SOFTWARE_PATH = r'\Wow6432Node' + X64_INSTALLED_SOFTWARE_PATH

--- a/regipy/plugins/software/last_logon.py
+++ b/regipy/plugins/software/last_logon.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 
 from inflection import underscore
 
@@ -6,7 +6,7 @@ from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 LAST_LOGON_KEY_PATH = r'\Microsoft\Windows\CurrentVersion\Authentication\LogonUI'
 

--- a/regipy/plugins/software/persistence.py
+++ b/regipy/plugins/software/persistence.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import get_subkey_values_from_list
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 PERSISTENCE_ENTRIES = [
     r'\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run',

--- a/regipy/plugins/software/printdemon.py
+++ b/regipy/plugins/software/printdemon.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 PORTS_KEY_PATH = r'\Microsoft\Windows NT\CurrentVersion\Ports'
 

--- a/regipy/plugins/software/profilelist.py
+++ b/regipy/plugins/software/profilelist.py
@@ -1,6 +1,6 @@
 import pytz
 import datetime
-import logbook
+import logging
 
 from regipy.exceptions import RegistryKeyNotFoundException, NoRegistryValuesException
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
@@ -9,7 +9,7 @@ from regipy.utils import get_subkey_values_from_list
 from regipy.utils import convert_wintime, convert_filetime
 
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 PROFILE_LIST_KEY_PATH = r"\Microsoft\Windows NT\CurrentVersion\ProfileList"
 

--- a/regipy/plugins/software/tracing.py
+++ b/regipy/plugins/software/tracing.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 TRACING_PATH = r'\Microsoft\Tracing'
 X86_TRACING_PATH = r'\Wow6432Node' + TRACING_PATH

--- a/regipy/plugins/software/uac.py
+++ b/regipy/plugins/software/uac.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SOFTWARE_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 UAC_KEY_PATH = r'\Microsoft\Windows\CurrentVersion\Policies\System'
 

--- a/regipy/plugins/system/active_controlset.py
+++ b/regipy/plugins/system/active_controlset.py
@@ -1,11 +1,11 @@
-import logbook
+import logging
 import attr
 
 from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 SELECT = r'\Select'
 

--- a/regipy/plugins/system/bam.py
+++ b/regipy/plugins/system/bam.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 
 from construct import Int64ul
 
@@ -7,7 +7,7 @@ from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 BAM_PATH = r'Services\bam\UserSettings'
 

--- a/regipy/plugins/system/computer_name.py
+++ b/regipy/plugins/system/computer_name.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 import attr
 
 from regipy.exceptions import RegistryValueNotFoundException
@@ -6,7 +6,7 @@ from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 COMPUTER_NAME_PATH = r'Control\ComputerName\ComputerName'
 

--- a/regipy/plugins/system/external/ShimCacheParser.py
+++ b/regipy/plugins/system/external/ShimCacheParser.py
@@ -23,7 +23,7 @@ import datetime
 import io as sio
 import struct
 
-import logbook
+import logging
 import pytz
 
 CACHE_MAGIC_NT5_2 = 0xbadc0ffe
@@ -62,7 +62,7 @@ G_VERBOSE = False
 G_USE_BOM = False
 OUTPUT_HEADER = ["Last Modified", "Last Update", "Path", "File Size", "Exec Flag"]
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Shim Cache format used by Windows 5.2 and 6.0 (Server 2003 through Vista/Server 2008)
 class CacheEntryNt5(object):

--- a/regipy/plugins/system/routes.py
+++ b/regipy/plugins/system/routes.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import get_subkey_values_from_list
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 ROUTES_PATH = r'Services\Tcpip\Parameters\PersistentRoutes'

--- a/regipy/plugins/system/safeboot_configuration.py
+++ b/regipy/plugins/system/safeboot_configuration.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy import RegistryKeyNotFoundException, convert_wintime
 from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 SAFEBOOT_NETWORK_PATH = r'Control\SafeBoot\Network'

--- a/regipy/plugins/system/services.py
+++ b/regipy/plugins/system/services.py
@@ -1,4 +1,4 @@
-import logbook
+import logging
 
 import attr
 from regipy.exceptions import RegistryKeyNotFoundException, NoRegistryValuesException, RegistryParsingException
@@ -6,7 +6,7 @@ from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.utils import convert_wintime
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 SERVICES_PATH = r'Services'
 

--- a/regipy/plugins/system/shimcache.py
+++ b/regipy/plugins/system/shimcache.py
@@ -1,10 +1,10 @@
-import logbook
+import logging
 
 from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.plugins.system.external.ShimCacheParser import get_shimcache_entries
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 COMPUTER_NAME_PATH = r'Control\Session Manager'
 

--- a/regipy/plugins/system/timezone_data.py
+++ b/regipy/plugins/system/timezone_data.py
@@ -1,12 +1,12 @@
 import attr
 
-import logbook
+import logging
 
 from regipy.hive_types import SYSTEM_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 TZ_DATA_PATH = r'Control\TimeZoneInformation'
 

--- a/regipy/plugins/utils.py
+++ b/regipy/plugins/utils.py
@@ -1,7 +1,7 @@
-import jsonlines
+import json
+import logging
 
 import attr
-import logging
 
 from regipy import NKRecord
 from regipy.plugins.plugin import PLUGINS
@@ -12,16 +12,17 @@ logger = logging.getLogger(__name__)
 
 def dump_hive_to_json(registry_hive, output_path, name_key_entry: NKRecord, verbose=False):
     """
-    Write the hive subkeys to a JSON file
+    Write the hive subkeys to a JSON-lines file, one line per entry.
     :param registry_hive: a RegistryHive object
     :param output_path: Output path to save the JSON
     :param name_key_entry: The NKRecord to start iterating from
     :param verbose: verbosity
     :return: The result, as dict
     """
-    with jsonlines.open(output_path, mode='w') as writer:
+    with open(output_path, mode='w') as writer:
         for entry in registry_hive.recurse_subkeys(name_key_entry, as_json=True):
-            writer.write(attr.asdict(entry))
+            writer.write(json.dumps(attr.asdict(entry), separators=(',', ':',)))
+            writer.write('\n')
 
 
 def run_relevant_plugins(registry_hive, as_json=False, plugins=None):
@@ -44,5 +45,3 @@ def run_relevant_plugins(registry_hive, as_json=False, plugins=None):
             plugin.run()
             plugin_results[plugin.NAME] = plugin.entries
     return plugin_results
-
-

--- a/regipy/plugins/utils.py
+++ b/regipy/plugins/utils.py
@@ -1,13 +1,13 @@
 import jsonlines
 
 import attr
-import logbook
+import logging
 
 from regipy import NKRecord
 from regipy.plugins.plugin import PLUGINS
 
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def dump_hive_to_json(registry_hive, output_path, name_key_entry: NKRecord, verbose=False):

--- a/regipy/recovery.py
+++ b/regipy/recovery.py
@@ -1,7 +1,7 @@
 import os
 from io import BytesIO
 
-import logbook
+import logging
 
 from construct import Int32ul
 
@@ -11,7 +11,7 @@ from regipy.hive_types import HVLE_TRANSACTION_LOG_MAGIC, DIRT_TRANSACTION_LOG_M
 from regipy.registry import RegistryHive
 from regipy.structs import TRANSACTION_LOG, REGF_HEADER_SIZE, REGF_HEADER, HBIN_HEADER
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _parse_hvle_block(hive_path, transaction_log_stream, log_size, expected_sequence_number):

--- a/regipy/regdiff.py
+++ b/regipy/regdiff.py
@@ -1,14 +1,14 @@
 import os
 from typing import Set
 
-import logbook
+import logging
 
 from regipy.exceptions import RegistryKeyNotFoundException
 
 from regipy.registry import RegistryHive, NKRecord
 from regipy.utils import convert_wintime, calculate_sha1
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_subkeys_and_timestamps(registry_hive):

--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -2,7 +2,7 @@ import binascii
 import datetime as dt
 
 
-import logbook
+import logging
 
 import attr
 
@@ -18,7 +18,7 @@ from regipy.structs import REGF_HEADER, HBIN_HEADER, CM_KEY_NODE, LF_LH_SK_ELEME
     BIG_DATA_BLOCK, INDEX_LEAF, DEFAULT_VALUE
 from regipy.utils import boomerang_stream, convert_wintime, identify_hive_type, MAX_LEN, try_decode_binary
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @attr.s

--- a/regipy/utils.py
+++ b/regipy/utils.py
@@ -1,14 +1,13 @@
-import pytz
-import attr
 import binascii
+import datetime as dt
 import hashlib
+import logging
 import sys
 
 from contextlib import contextmanager
-import datetime as dt
 from io import TextIOWrapper
 
-import logging
+import attr
 import pytz
 
 from regipy.exceptions import NoRegistrySubkeysException, RegistryKeyNotFoundException, RegipyGeneralException, \

--- a/regipy/utils.py
+++ b/regipy/utils.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 import datetime as dt
 from io import TextIOWrapper
 
-import logbook
+import logging
 import pytz
 
 from regipy.exceptions import NoRegistrySubkeysException, RegistryKeyNotFoundException, RegipyGeneralException, \
@@ -16,7 +16,7 @@ from regipy.exceptions import NoRegistrySubkeysException, RegistryKeyNotFoundExc
 from regipy.hive_types import NTUSER_HIVE_TYPE, SYSTEM_HIVE_TYPE, AMCACHE_HIVE_TYPE, SOFTWARE_HIVE_TYPE, \
     SAM_HIVE_TYPE
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Max size of string to return when as_json=True
 MAX_LEN = 128
@@ -156,5 +156,8 @@ def try_decode_binary(data, as_json=False, max_len=MAX_LEN):
     return value
 
 
-def _get_log_handlers(verbose):
-    return [logbook.StreamHandler(sys.stdout, level=logbook.DEBUG if verbose else logbook.INFO, bubble=True)]
+def _setup_logging(verbose):
+    logging.basicConfig(
+        fstream=sys.stdout, 
+        level=logging.DEBUG if verbose else logging.INFO,
+    )

--- a/regipy_tests/profiling.py
+++ b/regipy_tests/profiling.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from pstats import SortKey
 from tempfile import mktemp
 
-import logbook
+import logging
 
 from regipy.registry import RegistryHive
 
-logger = logbook.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @contextmanager

--- a/regipy_tests/tests.py
+++ b/regipy_tests/tests.py
@@ -245,4 +245,4 @@ def test_get_key(software_hive):
     registry_hive = RegistryHive(software_hive)
     # We verify the registry headers are similar, because this is the same subkey.
     assert registry_hive.get_key('ODBC').header == registry_hive.root.get_subkey('ODBC').header
-    assert registry_hive.root.get_subkey('ODBC').header == registry_hive.get_key('SOFTWARE\ODBC').header
+    assert registry_hive.root.get_subkey('ODBC').header == registry_hive.get_key('SOFTWARE\\ODBC').header

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ click>=7.0.0
 inflection==0.5.1
 jsonlines==2.0.0
 pytz==2021.1
-logbook==1.5.3
 tabulate==0.8.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ construct~=2.10.67
 attrs~=21.2.0
 click>=7.0.0
 inflection==0.5.1
-jsonlines==2.0.0
 pytz==2021.1
 tabulate==0.8.9

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,16 @@ def main():
           setup_requires=setup_requirements,
           install_requires=['construct~=2.10.67',
                             'attrs~=21.2.0',
-                            'click>=7.0.0',
                             'inflection==0.5.1',
-                            'jsonlines==2.0.0',
-                            'pytz==2021.1',
-                            'tabulate==0.8.9'],
+                            'pytz==2021.1'],
           tests_require=test_requirements,
           extras_require={
-              'test': test_requirements
+              'test': test_requirements,
+              'cli': [
+                  'click>=7.0.0',
+                  'jsonlines==2.0.0',
+                  'tabulate==0.8.9',
+              ],
           },
           include_package_data=True,
           keywords='Python, Python3, registry, windows registry, registry parser',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ def main():
                             'inflection==0.5.1',
                             'jsonlines==2.0.0',
                             'pytz==2021.1',
-                            'logbook==1.5.3',
                             'tabulate==0.8.9'],
           tests_require=test_requirements,
           extras_require={

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ def main():
                        'Programming Language :: Python',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
+                       'Programming Language :: Python :: 3.9',
                        'Topic :: Software Development :: Libraries',
                        'Topic :: Utilities'],
           entry_points={

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ def main():
           author='Martin G. Korman',
           author_email='martin@centauri.co.il',
           url='https://github.com/mkorman90/regipy/',
-          download_url='https://github.com/mkorman90/regipy/releases/download/1.0.0/regipy-1.0.0.tar.gz',
           license="MIT",
           setup_requires=setup_requirements,
           install_requires=['construct~=2.10.67',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ def main():
                        'Natural Language :: English',
                        'License :: OSI Approved :: MIT License',
                        'Programming Language :: Python',
+                       'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8',
                        'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ def main():
               'test': test_requirements,
               'cli': [
                   'click>=7.0.0',
-                  'jsonlines==2.0.0',
                   'tabulate==0.8.9',
               ],
           },


### PR DESCRIPTION
This PR resolves #171 and #172:
- #171 replace logbook by the standard library logging
- #172 make some deps optional with an extra_requires for [cli] to ease use as a library

It also removes the jsonlines dependency and uses instead the standard library `json` module to the same effect.

It makes also some minor extra changes such as:
- escaping a regex
- marking Python 3.6 and 3.9 as supported
- minor documentation adjustments

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
