### PR TITLE
Fix misc type errors reported by mypy

### DIFF
--- a/regipy/plugins/plugin.py
+++ b/regipy/plugins/plugin.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import Any, Dict, List, Optional
+
 from regipy.registry import RegistryHive
 
 PLUGINS = set()
@@ -9,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 class Plugin(object):
 
-    NAME = None
-    DESCRIPTION = None
-    COMPATIBLE_HIVE = None
+    NAME: Optional[str] = None
+    DESCRIPTION: Optional[str] = None
+    COMPATIBLE_HIVE: Optional[str] = None
 
     def __init_subclass__(cls):
         PLUGINS.add(cls)
@@ -23,7 +25,7 @@ class Plugin(object):
         self.partial_hive_path = registry_hive.partial_hive_path
 
         # This variable should always hold the final result - in order to use it in anomaly detection and timeline gen.
-        self.entries = list()
+        self.entries: List[Dict[str, Any]] = list()
 
     def can_run(self):
         """

--- a/regipy/plugins/system/external/ShimCacheParser.py
+++ b/regipy/plugins/system/external/ShimCacheParser.py
@@ -235,7 +235,7 @@ def get_shimcache_entries(cachebin, as_json=False):
         yield from read_win10_entries(cachebin, WIN10_MAGIC, creators_update=True, as_json=as_json)
 
     else:
-        raise Exception('Got an unrecognized magic value of 0x%x... bailing'.format(magic))
+        raise Exception('Got an unrecognized magic value of 0x{:x}... bailing'.format(magic))
 
 
 # Read Windows 8/2k12/8.1 Apphelp Cache entry formats.

--- a/regipy/regdiff.py
+++ b/regipy/regdiff.py
@@ -1,5 +1,5 @@
 import os
-from typing import Set
+from typing import Any, Set, Tuple
 
 import logging
 
@@ -36,13 +36,13 @@ def get_timestamp_for_subkeys(registry_hive, subkey_list):
         yield subkey_path, convert_wintime(subkey.header.last_modified, as_json=True)
 
 
-def _get_name_value_tuples(subkey: NKRecord) -> Set[tuple]:
+def _get_name_value_tuples(subkey: NKRecord) -> Set[Tuple[str, Any]]:
     """
     Iterate over value in a subkey and return a set of tuples containing value names and values
     :param subkey: NKRecord to iterate over
     :return: A set of tuples containing value names and values
     """
-    values_tuple = set()
+    values_tuple: Set[Tuple[str, Any]] = set()
     for value in subkey.iter_values(as_json=True):
         if not value.value:
             continue

--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -1,12 +1,14 @@
 import binascii
 import datetime as dt
 
+from typing import List, Optional, Union
 
 import logging
 
 import attr
 
-from construct import *
+from construct import Bytes, CString, EnumIntegerString, GreedyRange, Int32sl, Int32ul, Int64ul, \
+    StreamError, ConstError
 from io import BytesIO
 
 
@@ -26,9 +28,9 @@ class Cell:
     """
     Represents a Registry cell header
     """
-    offset = attr.ib(type=int)
-    cell_type = attr.ib(type=str)
-    size = attr.ib(type=int)
+    offset: int = attr.ib()
+    cell_type: str = attr.ib()
+    size: int = attr.ib()
 
 
 @attr.s
@@ -36,36 +38,36 @@ class VKRecord:
     """
     The VK Record contains a value
     """
-    value_type = attr.ib(type=EnumIntegerString)
-    value_type_str = attr.ib(type=str)
-    value = attr.ib(type=bytes)
-    size = attr.ib(type=int, default=0)
-    is_corrupted = attr.ib(type=bool, default=False)
+    value_type: EnumIntegerString = attr.ib()
+    value_type_str: str = attr.ib()
+    value: bytes = attr.ib()
+    size: int = attr.ib(default=0)
+    is_corrupted: bool = attr.ib(default=False)
 
 
 @attr.s
 class LIRecord:
-    data = attr.ib(type=bytes)
-
-
-@attr.s
-class Subkey:
-    subkey_name = attr.ib(type=str)
-    path = attr.ib(type=str)
-    timestamp = attr.ib(type=dt.datetime)
-    values_count = attr.ib(type=int)
-    values = attr.ib(factory=list)
-
-    # This field will be used if a partial hive was given, if not it would be None.
-    actual_path = attr.ib(type=str, default=None)
+    data: bytes = attr.ib()
 
 
 @attr.s
 class Value:
-    name = attr.ib(type=str)
-    value = attr.ib(type=(str or bytes))
-    value_type = attr.ib(type=str)
-    is_corrupted = attr.ib(type=bool, default=False)
+    name: str = attr.ib()
+    value: Union[str, int, bytes] = attr.ib()
+    value_type: str = attr.ib()
+    is_corrupted: bool = attr.ib(default=False)
+
+
+@attr.s
+class Subkey:
+    subkey_name: str = attr.ib()
+    path: str = attr.ib()
+    timestamp: dt.datetime = attr.ib()
+    values_count: int = attr.ib()
+    values: List[Value] = attr.ib(factory=list)
+
+    # This field will be used if a partial hive was given, if not it would be None.
+    actual_path: Optional[str] = attr.ib(default=None)
 
 
 class RIRecord:

--- a/regipy/utils.py
+++ b/regipy/utils.py
@@ -4,6 +4,8 @@ import hashlib
 import logging
 import sys
 
+from typing import Generator, Union
+
 from contextlib import contextmanager
 from io import TextIOWrapper
 
@@ -48,7 +50,7 @@ def calculate_xor32_checksum(b: bytes) -> int:
 
 
 @contextmanager
-def boomerang_stream(stream: TextIOWrapper) -> TextIOWrapper:
+def boomerang_stream(stream: TextIOWrapper) -> Generator[TextIOWrapper, None, None]:
     """
     Yield a stream that goes back to the original offset after exiting the "with" context
     :param stream: The stream
@@ -74,7 +76,7 @@ def convert_filetime(dw_low_date_time, dw_high_date_time):
         return None
 
 
-def convert_wintime(wintime: int, as_json=False) -> dt.datetime:
+def convert_wintime(wintime: int, as_json=False) -> Union[dt.datetime, str]:
     """
     Get an integer containing a FILETIME date
     :param wintime: integer representing a FILETIME timestamp


### PR DESCRIPTION
1. Update type annotations to match the current version of the code.
1. Use type annotations in place of `attr.ib(type=...)`.