### PR TITLE
Add a simple local machine SID extractor plugin 

### DIFF
--- a/regipy/plugins/__init__.py
+++ b/regipy/plugins/__init__.py
@@ -24,3 +24,4 @@ from .software.printdemon import PrintDemonPlugin
 from .system.timezone_data import TimezoneDataPlugin
 from .system.active_controlset import ActiveControlSetPlugin
 from .security.domain_sid import DomainSidPlugin
+from .sam.local_sid import LocalSidPlugin

--- a/regipy/plugins/sam/local_sid.py
+++ b/regipy/plugins/sam/local_sid.py
@@ -1,0 +1,50 @@
+"""
+Windows machine local SID extractor plugin
+"""
+
+import logging
+
+from regipy.hive_types import SAM_HIVE_TYPE
+from regipy.plugins.plugin import Plugin
+from regipy.structs import SID
+from regipy.utils import convert_wintime
+from regipy.security_utils import convert_sid
+
+logger = logging.getLogger(__name__)
+
+ACCOUNT_PATH = r"\SAM\Domains\Account"
+
+
+class LocalSidPlugin(Plugin):
+    """
+    Windows machine local SID extractor
+    """
+
+    NAME = "local_sid"
+    DESCRIPTION = "Get the machine local SID"
+    COMPATIBLE_HIVE = SAM_HIVE_TYPE
+
+    def run(self) -> None:
+        logger.info("Started Machine Local SID Plugin...")
+
+        account_key = self.registry_hive.get_key(ACCOUNT_PATH)
+
+        # A computer's SID is stored in the SECURITY hive
+        # under 'SECURITY\SAM\Domains\Account'.
+        # This key has a value named 'F' and a value named 'V'.
+        v_value = account_key.get_value("V")
+
+        # The 'V' value is a binary value that has the computer SID embedded
+        # within it at the end of its data.
+        sid_value = v_value[-24:]
+
+        parsed_sid = SID.parse(sid_value)
+
+        self.entries.append(
+            {
+                "machine_sid": convert_sid(parsed_sid),
+                "timestamp": convert_wintime(
+                    account_key.header.last_modified, as_json=self.as_json
+                ),
+            }
+        )

--- a/regipy_tests/conftest.py
+++ b/regipy_tests/conftest.py
@@ -50,6 +50,13 @@ def system_hive(test_data_dir):
 
 
 @pytest.fixture(scope='module')
+def sam_hive(test_data_dir):
+    temp_path = extract_lzma(os.path.join(test_data_dir, 'SAM.xz'))
+    yield temp_path
+    os.remove(temp_path)
+
+
+@pytest.fixture(scope='module')
 def amcache_hive(test_data_dir):
     temp_path = extract_lzma(os.path.join(test_data_dir, 'amcache.hve.xz'))
     yield temp_path

--- a/regipy_tests/plugin_tests.py
+++ b/regipy_tests/plugin_tests.py
@@ -8,6 +8,7 @@ from regipy.plugins.software.profilelist import ProfileListPlugin
 from regipy.plugins.software.persistence import SoftwarePersistencePlugin
 from regipy.plugins.system.computer_name import ComputerNamePlugin
 from regipy.plugins.system.shimcache import ShimCachePlugin
+from regipy.plugins.sam.local_sid import LocalSidPlugin
 from regipy.registry import RegistryHive
 
 
@@ -453,3 +454,16 @@ def test_services_plugin_on_corrupted_hive(corrupted_system_hive):
              'value_type': 'REG_DWORD'}
         ]
     }
+
+
+def test_local_sid_plugin_sam(sam_hive):
+    registry_hive = RegistryHive(sam_hive)
+    plugin_instance = LocalSidPlugin(registry_hive, as_json=True)
+    plugin_instance.run()
+
+    assert plugin_instance.entries == [
+        {
+            "machine_sid": "S-1-5-21-1760460187-1592185332-161725925",
+            "timestamp": "2014-09-24T03:36:43.549302+00:00"
+        }
+    ]


### PR DESCRIPTION
Include a sample plugin that operates on the SAM hive.
It gets the local machine SID (security id).

It adds some more test coverage for the recently added `SID` struct.