### PR TITLE
Use bit flags to determine the key and value names encoding

### DIFF
--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -293,12 +293,14 @@ class NKRecord:
         self.header = CM_KEY_NODE.parse_stream(stream)
         self._stream = stream
 
-        # Sometime the values are utf-8 and sometimes utf-16 little endian, we attempt both
-        try:
-            decoded_name = self.header.key_name_string.decode()
-        except UnicodeDecodeError:
-            decoded_name = self.header.key_name_string.decode('utf-16-le', errors='replace')
-        self.name = decoded_name
+        # Sometimes the key names are ASCII and sometimes UTF-16 little endian
+        if self.header.flags.KEY_COMP_NAME:
+            # Compressed (ASCII) key name
+            self.name = self.header.key_name_string.decode('ascii', errors='replace')
+        else:
+            # Unicode (UTF-16) key name
+            self.name = self.header.key_name_string.decode('utf-16-le', errors='replace')
+            logger.debug(f'Unicode key name identified: "{self.name}"')
 
         self.subkey_count = self.header.subkey_count
         self.values_count = self.header.values_count

--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -444,8 +444,13 @@ class NKRecord:
 
                 if vk.name_size == 0:
                     value_name = '(default)'
+                elif vk.flags.VALUE_COMP_NAME:
+                    # Compressed (ASCII) value name
+                    value_name = vk.name.decode('ascii', errors='replace')
                 else:
-                    value_name = vk.name.decode(errors='replace')
+                    # Unicode (UTF-16) value name
+                    value_name = vk.name.decode('utf-16-le', errors='replace')
+                    logger.debug(f'Unicode value name identified: "{value_name}"')
 
                 # If the value is bigger than this value, it means this is a DEVPROP structure
                 # https://doxygen.reactos.org/d0/dba/devpropdef_8h_source.html

--- a/regipy/structs.py
+++ b/regipy/structs.py
@@ -142,7 +142,7 @@ VALUE_KEY = Struct(
     'data_size' / Int32ul,
     'data_offset' / Int32ul,
     'data_type' / VALUE_TYPE_ENUM,
-    'flags' / Int16ul,
+    'flags' / FlagsEnum(Int16ul, VALUE_COMP_NAME=0x0001),
     'padding' * Int16ul,
     'name' / Bytes(this.name_size)
 ).compile()


### PR DESCRIPTION
Replace the key name decoding heuristic with the (semi-)documented
deterministic algorithm.

Define a new `VALUE_COMP_NAME` enum flag for the `VALUE_KEY.flags` field.
It has roughly the same meaning as the existing `KEY_COMP_NAME` enum flag.