### PR TITLE
Add boot key extraction plugin

### DIFF
--- a/regipy/plugins/__init__.py
+++ b/regipy/plugins/__init__.py
@@ -23,5 +23,6 @@ from .software.profilelist import ProfileListPlugin
 from .software.printdemon import PrintDemonPlugin
 from .system.timezone_data import TimezoneDataPlugin
 from .system.active_controlset import ActiveControlSetPlugin
+from .system.bootkey import BootKeyPlugin
 from .security.domain_sid import DomainSidPlugin
 from .sam.local_sid import LocalSidPlugin

--- a/regipy/plugins/system/bootkey.py
+++ b/regipy/plugins/system/bootkey.py
@@ -1,0 +1,92 @@
+"""
+The boot key is an encryption key that is stored in
+the Windows SYSTEM registry hive.
+
+This key is used by several Windows components to encrypt
+sensitive information like the AD database,
+machine account password or system certificates etc.
+"""
+
+import logging
+
+from regipy.registry import NKRecord
+from regipy.hive_types import SYSTEM_HIVE_TYPE
+from regipy.plugins.plugin import Plugin
+from regipy.utils import convert_wintime
+
+logger = logging.getLogger(__name__)
+
+LSA_KEY_PATH = r"Control\Lsa"
+
+
+def _collect_bootkey(lsa_key: NKRecord) -> str:
+    """
+    Extracts the 128-bit scrambled boot key from four "secret"
+    LSA subkeys as a 32-character hex string.
+    """
+
+    # The boot key is taken from four separate keys:
+    # SYSTEM\CurrentControlSet\Control\Lsa\{JD,Skew1,GBG,Data}.
+    # However, the actual data needed is stored in a hidden field of the key
+    # that cannot be seen using tools like regedit.
+    # Specifically, each part of the key is stored in the key's Class attribute,
+    # and is stored as a Unicode string giving the hex value of that piece of the key.
+
+    bootkey_subkeys = {
+        "JD": '',
+        "Skew1": '',
+        "GBG": '',
+        "Data": '',
+    }
+
+    for subkey in lsa_key.iter_subkeys():
+        if subkey.name in bootkey_subkeys:
+            bootkey_subkeys[subkey.name] = subkey.get_class_name()
+
+    return ''.join(bootkey_subkeys.values())
+
+
+# Permutation matrix for the boot key
+_BOOTKEY_PBOX = [
+    0x8, 0x5, 0x4, 0x2,
+    0xB, 0x9, 0xD, 0x3,
+    0x0, 0x6, 0x1, 0xC,
+    0xE, 0xA, 0xF, 0x7,
+]
+
+
+def _descramble_bootkey(key: str) -> bytes:
+    """
+    Parses the 128-bit binary boot key from a hex string
+    and reverses the bytewise scrambling transform.
+    """
+
+    binkey = bytes.fromhex(key)
+
+    return bytes([binkey[i] for i in _BOOTKEY_PBOX])
+
+
+class BootKeyPlugin(Plugin):
+    """
+    The boot key is an encryption key that is stored in
+    the Windows SYSTEM registry hive.
+    """
+
+    NAME = "bootkey"
+    DESCRIPTION = "Get the Windows boot key"
+    COMPATIBLE_HIVE = SYSTEM_HIVE_TYPE
+
+    def run(self):
+        logger.info("Started BootKey Plugin...")
+
+        for subkey_path in self.registry_hive.get_control_sets(LSA_KEY_PATH):
+            lsa_key = self.registry_hive.get_key(subkey_path)
+
+            bootkey = _descramble_bootkey(_collect_bootkey(lsa_key))
+
+            self.entries.append(
+                {
+                    "key": bootkey.hex() if self.as_json else bootkey,
+                    'timestamp': convert_wintime(lsa_key.header.last_modified, as_json=self.as_json)
+                }
+            )

--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -559,6 +559,19 @@ class NKRecord:
                 'sacl': sacl_aces
             }
 
+    def get_class_name(self) -> str:
+        """
+        Gets the key class name as would be returned via
+        the `lpClass` argument of the `RegQueryInfoKey()` function.
+        """
+
+        # Get the offset of the class name string. We skip 4 because of Cell Header
+        read_offset = REGF_HEADER_SIZE + 4 + self.header.class_name_offset
+
+        self._stream.seek(read_offset)
+        class_name = self._stream.read(self.header.class_name_size)
+
+        return class_name.decode('utf-16-le', errors='replace')
 
     def __dict__(self):
         return {

--- a/regipy_tests/plugin_tests.py
+++ b/regipy_tests/plugin_tests.py
@@ -8,6 +8,7 @@ from regipy.plugins.software.profilelist import ProfileListPlugin
 from regipy.plugins.software.persistence import SoftwarePersistencePlugin
 from regipy.plugins.system.computer_name import ComputerNamePlugin
 from regipy.plugins.system.shimcache import ShimCachePlugin
+from regipy.plugins.system.bootkey import BootKeyPlugin
 from regipy.plugins.sam.local_sid import LocalSidPlugin
 from regipy.registry import RegistryHive
 
@@ -466,4 +467,21 @@ def test_local_sid_plugin_sam(sam_hive):
             "machine_sid": "S-1-5-21-1760460187-1592185332-161725925",
             "timestamp": "2014-09-24T03:36:43.549302+00:00"
         }
+    ]
+
+
+def test_bootkey_plugin_system(system_hive):
+    registry_hive = RegistryHive(system_hive)
+    plugin_instance = BootKeyPlugin(registry_hive, as_json=True)
+    plugin_instance.run()
+
+    assert plugin_instance.entries == [
+        {
+            "key": "e7f28d88f470cfed67dbcdb62ed1275b",
+            "timestamp": "2012-04-04T11:47:46.203124+00:00",
+        },
+        {
+            "key": "e7f28d88f470cfed67dbcdb62ed1275b",
+            "timestamp": "2012-04-04T11:47:46.203124+00:00",
+        },
     ]


### PR DESCRIPTION
The boot key is an encryption key that is stored in
the Windows SYSTEM registry hive.

This key is used by several Windows components to encrypt
sensitive information like the AD database,
machine account password or system certificates etc.

Add a new `NKRecord` method for reading registry key class name strings.