### PR TITLE
Add HostDomainName plugin

### DIFF
--- a/regipy/plugins/__init__.py
+++ b/regipy/plugins/__init__.py
@@ -24,5 +24,6 @@ from .software.printdemon import PrintDemonPlugin
 from .system.timezone_data import TimezoneDataPlugin
 from .system.active_controlset import ActiveControlSetPlugin
 from .system.bootkey import BootKeyPlugin
+from .system.host_domain_name import HostDomainNamePlugin
 from .security.domain_sid import DomainSidPlugin
 from .sam.local_sid import LocalSidPlugin

--- a/regipy/plugins/system/host_domain_name.py
+++ b/regipy/plugins/system/host_domain_name.py
@@ -1,0 +1,37 @@
+import logging
+
+from regipy.hive_types import SYSTEM_HIVE_TYPE
+from regipy.plugins.plugin import Plugin
+from regipy.utils import convert_wintime
+
+logger = logging.getLogger(__name__)
+
+HOST_PARAMETERS_PATH = r'Services\Tcpip\Parameters'
+
+
+class HostDomainNamePlugin(Plugin):
+    NAME = 'host_domain_name'
+    DESCRIPTION = 'Get the computer host and domain names'
+    COMPATIBLE_HIVE = SYSTEM_HIVE_TYPE
+
+    def run(self):
+        logger.info('Started Host and Domain Name Plugin...')
+
+        for subkey_path in self.registry_hive.get_control_sets(HOST_PARAMETERS_PATH):
+            subkey = self.registry_hive.get_key(subkey_path)
+
+            hostname = subkey.get_value('Hostname', as_json=self.as_json)
+            domain = subkey.get_value('Domain', as_json=self.as_json)
+
+            # The default key value is 0x00000000 (REG_DWORD) when
+            # the Windows machine is not in an AD domain.
+            if not isinstance(domain, str):
+                domain = None
+
+            self.entries.append({
+                'hostname': hostname,
+                'domain': domain,
+                'timestamp': convert_wintime(subkey.header.last_modified, as_json=self.as_json)
+            })
+
+

--- a/regipy_tests/plugin_tests.py
+++ b/regipy_tests/plugin_tests.py
@@ -9,6 +9,7 @@ from regipy.plugins.software.persistence import SoftwarePersistencePlugin
 from regipy.plugins.system.computer_name import ComputerNamePlugin
 from regipy.plugins.system.shimcache import ShimCachePlugin
 from regipy.plugins.system.bootkey import BootKeyPlugin
+from regipy.plugins.system.host_domain_name import HostDomainNamePlugin
 from regipy.plugins.sam.local_sid import LocalSidPlugin
 from regipy.registry import RegistryHive
 
@@ -483,5 +484,24 @@ def test_bootkey_plugin_system(system_hive):
         {
             "key": "e7f28d88f470cfed67dbcdb62ed1275b",
             "timestamp": "2012-04-04T11:47:46.203124+00:00",
+        },
+    ]
+
+
+def test_host_domain_name_plugin_system(system_hive):
+    registry_hive = RegistryHive(system_hive)
+    plugin_instance = HostDomainNamePlugin(registry_hive, as_json=True)
+    plugin_instance.run()
+
+    assert plugin_instance.entries == [
+        {
+            "hostname": "WKS-WIN732BITA",
+            "domain": "shieldbase.local",
+            "timestamp": "2011-09-17T13:43:23.770078+00:00"
+        },
+        {
+            "hostname": "WKS-WIN732BITA",
+            "domain": "shieldbase.local",
+            "timestamp": "2011-09-17T13:43:23.770078+00:00"
         },
     ]


### PR DESCRIPTION
It extracts the DNS hostname and DNS domain name, which do not necessarily
match the Windows computer name and the Windows domain name.

Add a trivial plugin unit test.