### PR TITLE
Fix more mypy type errors

### DIFF
--- a/regipy/plugins/security/domain_sid.py
+++ b/regipy/plugins/security/domain_sid.py
@@ -4,6 +4,8 @@ Windows machine domain name and SID extractor plugin
 
 import logging
 
+from typing import Optional
+
 from regipy.hive_types import SECURITY_HIVE_TYPE
 from regipy.plugins.plugin import Plugin
 from regipy.structs import SID
@@ -41,6 +43,9 @@ class DomainSidPlugin(Plugin):
         # Domain SID value (binary-encoded)
         sid_value = sid_key.get_value()
 
+        domain_sid: Optional[str] = None
+        machine_sid: Optional[str] = None
+
         # The default key value is 0x00000000 (REG_DWORD) when
         # the Windows machine is not in an AD domain.
         # Otherwise, it contains the domain machine SID data
@@ -49,9 +54,6 @@ class DomainSidPlugin(Plugin):
             parsed_sid = SID.parse(sid_value)
             domain_sid = convert_sid(parsed_sid, strip_rid=True)
             machine_sid = convert_sid(parsed_sid)
-        else:
-            domain_sid = None
-            machine_sid = None
 
         self.entries.append(
             {

--- a/regipy/security_utils.py
+++ b/regipy/security_utils.py
@@ -1,11 +1,12 @@
 import struct
 from struct import unpack
 
+from typing import Any
 from regipy.exceptions import NtSidDecodingException
 from regipy.structs import ACL, ACE, SID, Int64ub
 
 
-def convert_sid(sid: SID, strip_rid: bool = False) -> str:
+def convert_sid(sid: Any, strip_rid: bool = False) -> str:
     identifier_authority = Int64ub.parse(b'\x00\x00' + sid.identifier_authority)
     sub_authorities = sid.subauthority[:-1] if strip_rid else sid.subauthority
     sub_identifier_authorities = '-'.join(str(x) for x in sub_authorities)


### PR DESCRIPTION
Unfortunately, construct-generated types can not be used in type
annotations, at least with the current version of construct-typing.
Replace them with typing.Any