### PR TITLE
fix syntaxwarning in python 3.12

### DIFF
--- a/regipy/plugins/ntuser/shellbags_ntuser.py
+++ b/regipy/plugins/ntuser/shellbags_ntuser.py
@@ -219,7 +219,7 @@ class ShellBagNtuserPlugin(Plugin):
             node_slot = ''
 
         for v in key.iter_values(trim_values=False):
-            if re.match("\d+", v.name):
+            if re.match(r"\d+", v.name):
                 slot = v.name
                 byte_stream = v.value
                 shell_items = pyfwsi.item_list()

--- a/regipy/plugins/usrclass/shellbags_usrclass.py
+++ b/regipy/plugins/usrclass/shellbags_usrclass.py
@@ -223,7 +223,7 @@ class ShellBagUsrclassPlugin(Plugin):
             node_slot = ''
 
         for v in key.iter_values(trim_values=False):
-            if re.match("\d+", v.name):
+            if re.match(r"\d+", v.name):
                 slot = v.name
                 byte_stream = v.value
                 shell_items = pyfwsi.item_list()


### PR DESCRIPTION
With python 3.12 some syntax is raising SyntaxWarning:

```
 /usr/local/lib/python3.12/site-packages/regipy/plugins/ntuser/shellbags_ntuser.py:222: SyntaxWarning: invalid escape sequence '\d'
   if re.match("\d+", v.name):
 /usr/local/lib/python3.12/site-packages/regipy/plugins/usrclass/shellbags_usrclass.py:226: SyntaxWarning: invalid escape sequence '\d'
   if re.match("\d+", v.name):
```

Making the string literal with raw should easily resolve the issue.