### PR TITLE
Fixed MRUListEx Parsing in Shellbags plugins

### DIFF
--- a/regipy/plugins/ntuser/shellbags_ntuser.py
+++ b/regipy/plugins/ntuser/shellbags_ntuser.py
@@ -23,7 +23,8 @@ class ShellBagNtuserPlugin(Plugin):
         if isinstance(mru_val, bytes):
             mru_val = mru_val[:-4]
             for i in range(0, len(mru_val), 4):
-                mru_order_string += f"{str(mru_val[i])}-"
+                current_val = int.from_bytes(mru_val[i: i + 4], byteorder="little")
+                mru_order_string += f"{current_val}-"
 
             return mru_order_string[:-1]
         else:

--- a/regipy/plugins/usrclass/shellbags_usrclass.py
+++ b/regipy/plugins/usrclass/shellbags_usrclass.py
@@ -23,7 +23,8 @@ class ShellBagUsrclassPlugin(Plugin):
         if isinstance(mru_val, bytes):
             mru_val = mru_val[:-4]
             for i in range(0, len(mru_val), 4):
-                mru_order_string += f"{str(mru_val[i])}-"
+                current_val = int.from_bytes(mru_val[i: i + 4], byteorder="little")
+                mru_order_string += f"{current_val}-"
 
             return mru_order_string[:-1]
         else:


### PR DESCRIPTION
The `MRUListEx` value isn't parsed correctly in the two Shellbags plugins (NTUSER.DAT and UsrClass.dat)
This causes the plugin to crash. It tries to find specific values in the malformed MRU list and fails:
![image](https://github.com/user-attachments/assets/63126570-465e-43b1-8301-75a120cc3a48)

This happens because each value in the MRU list is 4 bytes, but only the first byte is parsed.