### PR TITLE
fix: resolve get_key paths that lack a leading backslash

### DIFF
--- a/regipy/registry.py
+++ b/regipy/registry.py
@@ -271,7 +271,14 @@ class RegistryHive:
 
         # If the path contain slashes, this is a full path. Split it
         if "\\" in key_path:
-            key_path_parts = key_path.split("\\")[1:]
+            key_path_parts = key_path.split("\\")
+            if not key_path_parts[0]:
+                # The path started with a backslash, drop the empty first part
+                key_path_parts = key_path_parts[1:]
+            elif not self.root.get_subkey(key_path_parts[0], raise_on_missing=False):
+                # The first part is not a subkey of the root, so it is the hive
+                # name prefix (for example SOFTWARE\ODBC) and should be dropped
+                key_path_parts = key_path_parts[1:]
         else:
             key_path_parts = [key_path]
 

--- a/regipy_tests/tests.py
+++ b/regipy_tests/tests.py
@@ -278,6 +278,15 @@ def test_get_key(software_hive):
     assert registry_hive.root.get_subkey("ODBC").header == registry_hive.get_key("SOFTWARE\\ODBC").header
 
 
+def test_get_key_without_leading_backslash(system_hive):
+    """
+    # Refers to https://github.com/mkorman90/regipy/issues/323
+    """
+    registry_hive = RegistryHive(system_hive)
+    expected = registry_hive.get_key(r"\ControlSet001\Control\ComputerName\ComputerName")
+    assert registry_hive.get_key(r"ControlSet001\Control\ComputerName\ComputerName").header == expected.header
+
+
 def test_get_subkey_errors(software_hive):
     registry_hive = RegistryHive(software_hive)
     # Tests the NoRegistrySubkeysException that suppose to be raised


### PR DESCRIPTION
Closes #323

`get_key()` split the path on backslash and always dropped the first segment, which assumes a leading backslash (or a hive-name prefix like `SOFTWARE\ODBC`). So `get_key(r"ControlSet001\Control\ComputerName\ComputerName")` silently lost `ControlSet001` and raised `RegistryKeyNotFoundException`.

The first segment is now dropped only when it is empty (leading backslash) or when it is not actually a subkey of the root, so the existing hive-prefix form keeps working. Regression test added next to `test_get_key`.
